### PR TITLE
Replace FAA with FADD

### DIFF
--- a/data/tests/on_thin_air_reads19/ex3.5.lit
+++ b/data/tests/on_thin_air_reads19/ex3.5.lit
@@ -14,4 +14,4 @@ z := 0;
   x := r2
 }
 %%
-forbid (r2 = 1) [JR = forbid]
+forbid (r1 != 0) [JR = forbid]

--- a/data/tests/popl_grounding/coh-cyc_promising.lit
+++ b/data/tests/popl_grounding/coh-cyc_promising.lit
@@ -1,0 +1,21 @@
+name="Coh-CYC"
+values={0,1,2,3}
+%%
+x := 0;
+y := 0;
+{
+   x := 2;
+   r1 := x;
+   if (r1 != 2) {
+     y := 1;
+   }
+} ||| {
+  x := 1;
+  r2 := x;
+  r3 := y;
+  if(r3 != 0) {
+    y := 3
+  }
+}
+%%
+forbid (r1 = 3 && r2 = 2 && r3 = 1) [Promising=forbid] "Edge case."

--- a/data/tests/popl_grounding/coh-cyc_soham.lit
+++ b/data/tests/popl_grounding/coh-cyc_soham.lit
@@ -18,4 +18,4 @@ y := 0;
   }
 }
 %%
-forbid (r1 = 3 && r2 = 2 && r3 = 1) [Promising=allow, Soham=forbid] "Edge case."
+allow (r1 = 3 && r2 = 2 && r3 = 1) [Soham=allow] "Edge case."

--- a/data/tests/popl_promising/p7c1b.lit
+++ b/data/tests/popl_promising/p7c1b.lit
@@ -7,7 +7,7 @@ comment "Section 4.1: Release/Acquire Synchronization; Page 7, Column 1 (b)"
   y.store(1, rel);
   y := 2
 } ||| {
-  r1 = FADD(y, rlx, rlx, 1)
+  r1 := FADD(y, rlx, rlx, 1)
 }} ||| {
   r2 := y.load(acq); // 3
   r3 := x // <> 0

--- a/data/tests/popl_promising/p7c1b.lit
+++ b/data/tests/popl_promising/p7c1b.lit
@@ -7,7 +7,7 @@ comment "Section 4.1: Release/Acquire Synchronization; Page 7, Column 1 (b)"
   y.store(1, rel);
   y := 2
 } ||| {
-  r1 = FAA(y, 1)
+  r1 = FADD(y, rlx, rlx, 1)
 }} ||| {
   r2 := y.load(acq); // 3
   r3 := x // <> 0

--- a/data/tests/popl_promising/p7c1b.lit
+++ b/data/tests/popl_promising/p7c1b.lit
@@ -13,4 +13,4 @@ comment "Section 4.1: Release/Acquire Synchronization; Page 7, Column 1 (b)"
   r3 := x // <> 0
 }
 %%
-forbid (r2 = 3 && r3 = 0) [Promising=allow] "Release sequence"
+forbid (r2 = 3 && r3 = 0) [Promising=forbid] "Release sequence"

--- a/data/tests/test6/CoWW.lit
+++ b/data/tests/test6/CoWW.lit
@@ -10,5 +10,5 @@ values={0,1,2}
   r2 := x
 }
 %%
-forbid (r1 = 2 && r2 = 1) [] ""
+forbid (r1 = 2 && r2 = 1) [Power=forbid] ""
 

--- a/data/tests/test6/ISA2+Fsc+Fsc.lit
+++ b/data/tests/test6/ISA2+Fsc+Fsc.lit
@@ -18,4 +18,4 @@ z := 0;
   r3 := x
 }
 %%
-forbid (r1 = 1 && r2 = 1 && r3 = 0) [Power=allow]
+forbid (r1 = 1 && r2 = 1 && r3 = 0) [Power=forbid]

--- a/data/tests/test6/MP+rel+acq.lit
+++ b/data/tests/test6/MP+rel+acq.lit
@@ -11,4 +11,4 @@ y := 0;
   r2 := x
 }
 %%
-forbid (r1 = 1 && r2 = 0) [Power=allow]
+forbid (r1 = 1 && r2 = 0) [Power=forbid]


### PR DESCRIPTION
This seems fine to do since the result is ignored anyway (so it would have the same behaviour in this case), and it is the only test that makes use of 'FAA', hence why I want to remove it.